### PR TITLE
Pull in upstream CI/build updates (Dockerfile toolchain + action versions)

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: oryx
 
@@ -119,7 +119,7 @@ jobs:
           echo normalized_layout_geometry=${normalized_layout_geometry} >> "$GITHUB_OUTPUT"
 
       - name: Upload layout
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build-layout.outputs.normalized_layout_geometry }}_${{ github.event.inputs.layout_id }}_${{ github.run_id }}
           path: ${{ steps.build-layout.outputs.built_layout_file }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM debian:latest
 
-RUN apt update && apt install -y git python3 python3-pip sudo
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
+    python3-pip \
+    sudo \
+    build-essential \
+    gcc-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    avrdude \
+    dfu-util
 
 RUN python3 -m pip install qmk appdirs --break-system-packages
 


### PR DESCRIPTION
Cherry-picks two maintenance commits from upstream (`poulainpi/oryx-with-custom-qmk`) that keep the `fetch-and-build-layout` workflow healthy. The Moonlander layout-option split (#55 upstream) was deliberately skipped as irrelevant to this fork.

## Changes

- **Dockerfile toolchain** (upstream #57, `8d394b2`): adds `build-essential`, `gcc-arm-none-eabi`, `libnewlib-arm-none-eabi`, `avrdude`, and `dfu-util`. The build image previously shipped no compiler, so recent ARM-target firmware builds would fail the `make` step. Titled "firmware v24 compatibility" upstream.
- **Action versions** (upstream #63, `26bfbe6`): `actions/checkout@v4 → v5`, `actions/upload-artifact@v4 → v7`. Moves both onto the Node 24 runtime, ahead of GitHub's deprecation of older runtimes.

## Why

The `@v4` pins still run today, but the toolchain gap could already break ARM builds, and the runtime bump avoids future hard failures. Low risk: the workflow uses only the stable `name`/`path` core of `upload-artifact`.

## Testing

To be validated by triggering `fetch-and-build-layout` off this branch and confirming a green `ergodox_ez` build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)