### PR TITLE
Reconcile QMK/ZMK extend-layer parity (func, num, wnum)

### DIFF
--- a/DYrAK/keymap.c
+++ b/DYrAK/keymap.c
@@ -70,7 +70,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,                                                                                                 KC_0,           KC_0,           KC_KP_DOT,      KC_KP_ENTER,    KC_TRANSPARENT,
                                                                                                     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,
                                                                                                                     KC_BRIGHTNESS_UP,KC_TRANSPARENT,
-                                                                                    KC_BSPC,        KC_DELETE,      KC_BRIGHTNESS_DOWN,KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT
+                                                                                    KC_BSPC,        KC_DELETE,      KC_BRIGHTNESS_DOWN,KC_TRANSPARENT, KC_ENTER,       KC_TRANSPARENT
   ),
   [5] = LAYOUT_ergodox_pretty( // ext-wnav
     KC_TRANSPARENT, KC_F1,          KC_F2,          KC_F3,          KC_F4,          KC_F5,          KC_TRANSPARENT,                                 KC_TRANSPARENT, KC_F6,          KC_F7,          KC_F8,          KC_F9,          KC_F10,         KC_F11,
@@ -90,7 +90,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,                                                                                                 KC_0,           KC_0,           KC_KP_DOT,      KC_KP_ENTER,    KC_TRANSPARENT,
                                                                                                     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,
                                                                                                                     KC_BRIGHTNESS_UP,KC_TRANSPARENT,
-                                                                                    KC_BSPC,        KC_DELETE,      KC_BRIGHTNESS_DOWN,KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT
+                                                                                    KC_BSPC,        KC_DELETE,      KC_BRIGHTNESS_DOWN,KC_TRANSPARENT, KC_ENTER,       KC_TRANSPARENT
   ),
   [7] = LAYOUT_ergodox_pretty( // ext-func
     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,                                 KC_TRANSPARENT, KC_TRANSPARENT, KC_F10,         KC_F11,         KC_F12,         KC_TRANSPARENT, KC_TRANSPARENT,
@@ -100,7 +100,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,                                                                                                 KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,
                                                                                                     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,
                                                                                                                     KC_BRIGHTNESS_UP,KC_TRANSPARENT,
-                                                                                    KC_TRANSPARENT, KC_TRANSPARENT, KC_BRIGHTNESS_DOWN,KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT
+                                                                                    KC_BSPC,        KC_DELETE,      KC_BRIGHTNESS_DOWN,KC_TRANSPARENT, KC_ENTER,       KC_SPACE
   ),
   [8] = LAYOUT_ergodox_pretty( // mouse
     KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,                                 KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,

--- a/LAYERS.md
+++ b/LAYERS.md
@@ -242,18 +242,12 @@ _QMK ✓ (`DYrAK` layer 4: ext-num)_
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        ▽     KP_DIVID KP_MULTI  MINUS      ▽    
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        7        8        9     KP_PLUS     ▽    
      ▽       sk⇧      sk⌃      sk⌥      sk⌘       ▽           ▽        4        5        6     KP_PLUS     ▽    
-     ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        1        2        3     KP_ENTER    ▽    
+     ▽        ▽        ▽        ▽        ▽        ▽       LPAR        RPAR      ▽        1        2        3     KP_ENTER    ▽    
      ▽        ▽        ▽        ▽        ▽           0        0      KP_DOT  KP_ENTER    ▽    
 
   thumbs   L:    ▽         ▽      |    BSPC      DEL       bri+    |    bri-  
            R:    ▽         ▽      |     ▽        RET        ▽      |     ▽    
 ```
-
-**QMK differs here (3):**
-
-- pos 47: QMK `KC_LPRN` vs ZMK `&trans`
-- pos 48: QMK `KC_RPRN` vs ZMK `&trans`
-- pos 75: QMK `KC_TRANSPARENT` vs ZMK `&kp RET`
 
 ### 9. extend-win-nav
 
@@ -289,18 +283,12 @@ _QMK ✓ (`DYrAK` layer 6: ext-wnum)_
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        ▽     KP_DIVID KP_MULTI  MINUS      ▽    
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        7        8        9     KP_PLUS     ▽    
      ▽       sk⇧      sk⌘      sk⌥      sk⌃       ▽           ▽        4        5        6     KP_PLUS     ▽    
-     ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        1        2        3     KP_ENTER    ▽    
+     ▽        ▽        ▽        ▽        ▽        ▽       LPAR        RPAR      ▽        1        2        3     KP_ENTER    ▽    
      ▽        ▽        ▽        ▽        ▽           0        0      KP_DOT  KP_ENTER    ▽    
 
   thumbs   L:    ▽         ▽      |    BSPC      DEL       bri+    |    bri-  
            R:    ▽         ▽      |     ▽        RET        ▽      |     ▽    
 ```
-
-**QMK differs here (3):**
-
-- pos 47: QMK `KC_LPRN` vs ZMK `&trans`
-- pos 48: QMK `KC_RPRN` vs ZMK `&trans`
-- pos 75: QMK `KC_TRANSPARENT` vs ZMK `&kp RET`
 
 ### 11. extend-func
 
@@ -317,13 +305,6 @@ _QMK ✓ (`DYrAK` layer 7: ext-func)_
   thumbs   L:    ▽         ▽      |    BSPC      DEL       bri+    |    bri-  
            R:    ▽         ▽      |     ▽        RET      SPACE    |     ▽    
 ```
-
-**QMK differs here (4):**
-
-- pos 71: QMK `KC_TRANSPARENT` vs ZMK `&kp BSPC`
-- pos 72: QMK `KC_TRANSPARENT` vs ZMK `&kp DEL`
-- pos 75: QMK `KC_TRANSPARENT` vs ZMK `&kp RET`
-- pos 76: QMK `KC_TRANSPARENT` vs ZMK `&kp SPACE`
 
 ### 12. mouse
 

--- a/LAYOUT_CONVENTIONS.md
+++ b/LAYOUT_CONVENTIONS.md
@@ -81,6 +81,25 @@ A large tree, mac-oriented:
 - `LAYER_ID` (QMK speak-layer-name) is QMK-only.
 - `mouse`/`layers` utility keys differ by firmware capability.
 
+## QMK ⇄ ZMK parity edits
+
+Reconciled 2026-06-15. Default direction is ZMK (the home superset) canonical
+with QMK brought up to match, but it's decided **per-key** — pos 47/48 below
+went the other way (QMK won). Confirm each; don't blanket-resolve.
+
+- **Done:** `ext-func` thumbs (pos 71/72/75/76 → BSPC/DEL/ENTER/SPACE) and
+  `ext-num`/`ext-wnum` pos 75 (ENTER) brought up to ZMK. `ext-num`/`ext-wnum`
+  pos 47/48 reconciled to parens — ZMK updated to QMK's `(`/`)` so the number
+  layer types parens, not the base brackets (`[`/`]`).
+- **base-old port** — complete QMK `[2]` base-old to mirror ZMK's full
+  traditional-mod QWERTY. QMK currently has only the skeleton (mods + partial
+  home row); the alpha/number/symbol field and arrows are still missing.
+- **win-nav** — add three keys QMK `ext-wnav` `[5]` dropped vs ZMK (and vs QMK's
+  own mac-nav): pos 29 `CW_TOGG`, pos 69 `KC_MEDIA_NEXT_TRACK`, pos 73
+  `KC_MEDIA_PREV_TRACK`.
+- **mouse pos 67** — add `TO(9)` to QMK `mouse` `[8]`; there is currently no way
+  back to the layers layer from mouse (a real gap, not a firmware divergence).
+
 ## Open questions for Forrest
 
 - Should any home-only ZMK layer ever come to QMK, or is the split permanent?

--- a/config/slicemk_ergodox.keymap
+++ b/config/slicemk_ergodox.keymap
@@ -603,8 +603,8 @@
   &trans     &sk LSHFT  &sk LCTRL  &sk LALT   &sk LGUI   &trans                                  &trans     &kp N4     &kp N5     &kp N6     &kp KP_PLUS &trans
 //│ TRANS    │ SHIFT    │ CTRL     │ ALT      │ GUI      │ TRANS    │          │      │          │ TRANS    │ 4        │ 5        │ 6        │ KP +     │ TRANS    │ 
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &trans     &kp N1     &kp N2     &kp N3     &kp KP_ENTER &trans
-//│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │      │ TRANS    │ TRANS    │ 1        │ 2        │ 3        │ KP ENTER │ TRANS    │ 
+  &trans     &trans     &trans     &trans     &trans     &trans     &kp LPAR          &kp RPAR   &trans     &kp N1     &kp N2     &kp N3     &kp KP_ENTER &trans
+//│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ (        │      │ )        │ TRANS    │ 1        │ 2        │ 3        │ KP ENTER │ TRANS    │
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans                                                        &kp N0     &kp N0     &kp KP_DOT &kp KP_ENTER &trans
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │          │          │      │                     │ 0        │ 0        │ KP .     │ KP ENTER │ TRANS    │
@@ -667,8 +667,8 @@
   &trans     &sk LSHFT  &sk LGUI   &sk LALT   &sk LCTRL  &trans                                  &trans     &kp N4     &kp N5     &kp N6     &kp KP_PLUS &trans
 //│ TRANS    │ SHIFT    │ WIN      │ ALT      │ CTRL     │ TRANS    │          │      │          │ TRANS    │ 4        │ 5        │ 6        │ KP +     │ TRANS    │ 
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &trans     &kp N1     &kp N2     &kp N3     &kp KP_ENTER &trans
-//│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │      │ TRANS    │ TRANS    │ 1        │ 2        │ 3        │ KP ENTER │ TRANS    │ 
+  &trans     &trans     &trans     &trans     &trans     &trans     &kp LPAR          &kp RPAR   &trans     &kp N1     &kp N2     &kp N3     &kp KP_ENTER &trans
+//│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ (        │      │ )        │ TRANS    │ 1        │ 2        │ 3        │ KP ENTER │ TRANS    │
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans                                                        &kp N0     &kp N0     &kp KP_DOT &kp KP_ENTER &trans
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │          │          │      │                     │ 0        │ 0        │ KP .     │ KP ENTER │ TRANS    │


### PR DESCRIPTION
## What

Reconcile the shared **extend layers** between the QMK work board
(`DYrAK/keymap.c`) and the ZMK home board (`config/slicemk_ergodox.keymap`).
`func`, `num`, and `wnum` now report **zero** parity drift (`parity.py`).

## Changes

| Layer | Side edited | Change |
|---|---|---|
| `ext-func` | QMK | Fill thumb keys 71/72/75/76 → `BSPC`/`DEL`/`ENTER`/`SPACE` (were transparent) |
| `ext-num` / `ext-wnum` | QMK | Add `ENTER` at right inner thumb (pos 75) |
| `ext-num` / `ext-wnum` | ZMK | Parens at pos 47/48 (`&kp LPAR`/`&kp RPAR`) so the number layer types `(` `)` rather than falling through to base `[` `]` |

Direction was decided **per-key**: ZMK is usually canonical, but parens on the
number layer were kept from QMK.

## Docs / housekeeping

- `LAYOUT_CONVENTIONS.md`: records the decisions and the still-deferred items
  (base-old port, win-nav keys, mouse return-to-layers).
- `LAYERS.md`: regenerated (drift markers for the three synced layers cleared).

## Not verified

Static analysis only. **Not build-tested or flashed.** Firmware builds are
CI-only:
- QMK → `fetch-and-build-layout` Action
- ZMK → `build-zmk-layout` Action

🤖 Generated with [Claude Code](https://claude.com/claude-code)
