### PR TITLE
Fix ZMK build: dead fork ref + board-compat workflow skew

### DIFF
--- a/.github/workflows/build-zmk-layout.yml
+++ b/.github/workflows/build-zmk-layout.yml
@@ -4,7 +4,10 @@ on: [workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    # slicemk/zmk's reusable workflow, NOT zmkfirmware upstream: upstream@main added a
+    # board-compat (`west boards` / CONFIG_ZMK_BOARD_COMPAT) step that the slicemk fork
+    # doesn't implement, which breaks the build. Matches xudongzheng's working underglow config.
+    uses: slicemk/zmk/.github/workflows/build-user-config.yml@main
     with:
       build_matrix_path: build.yaml
       config_path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -11,7 +11,9 @@ manifest:
   projects:
     - name: zmk
       remote: slicemk
-      revision: v20250729-rgb
+      # xudongzheng/zmk v20251223-rgb tip, SHA-pinned: he prunes old date-stamped
+      # branches (v20250729-rgb vanished and broke the build); a SHA survives that.
+      revision: 997e147744047475bcc9a00e28fc40c9d9a1e91e
       import: app/west.yml
     - name: zmk-helpers
       remote: urob


### PR DESCRIPTION
## Why

The ZMK firmware build broke on **two independent upstream changes** since the last successful build (Dec 2025):

1. **Dead fork ref.** xudongzheng pruned `v20250729-rgb` from `xudongzheng/zmk`, so `west update` can't fetch ZMK → no app, no `.config`.
2. **Workflow skew.** `zmkfirmware/zmk`'s reusable `build-user-config.yml@main` added a board-compat step (`west boards` / `CONFIG_ZMK_BOARD_COMPAT`) that the slicemk fork doesn't implement — the exact error in the build log.

## Changes

- **`config/west.yml`** — zmk revision `v20250729-rgb` → `997e147…` (SHA-pinned tip of `v20251223-rgb`, the current RGB-underglow branch). SHA-pinned on purpose: branch pruning is what broke it.
- **`.github/workflows/build-zmk-layout.yml`** — reusable workflow `zmkfirmware/zmk` → `slicemk/zmk` (no board-compat step; matches xudongzheng's working `underglow` config).

Other modules (zmk-helpers, leader-key, tri-state, listeners) unchanged.

## Verification

⚠️ **Static only — not yet built.** Confirm by running the **Build ZMK Layout** Action (`workflow_dispatch`) — it can be dispatched against this branch before merge. Confidence it clears both errors: ~85%; residual risk is the still-abandoned upstream (`slicemk/zmk@main`, `v20251223-rgb`).

Deferred follow-up: self-fork `xudongzheng/zmk` + `slicemk/zmk` into DivisionSt to insulate from further pruning/drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
