### PR TITLE
ZMK sticky key enhancements: 3s timeout, lazy mode, hold-to-hold

### DIFF
--- a/LAYERS.md
+++ b/LAYERS.md
@@ -221,7 +221,7 @@ _QMK ✓ (`DYrAK` layer 3: ext-nav)_
 ```
      ▽        F1       F2       F3       F4       F5       ▽           ▽        F6       F7       F8       F9      F10      F11   
      ▽        ▽        ▽        ▽        ▽        ▽      ⌘GRAVE        ▽        ▽        ▽        ▽        ▽        ▽       F12   
-    CAPS     sk⇧      sk⌃      sk⌥      sk⌘      ⌃TAB        LEFT     DOWN      UP     RIGHT      ▽        ▽    
+    CAPS    skht⇧    skht⌃    skht⌥    skht⌘     ⌃TAB        LEFT     DOWN      UP     RIGHT      ▽        ▽    
      ▽        ▽        ▽        ▽        ▽      ⌘LEFT     LPAR        RPAR      ▽      PG_DN    PG_UP      ▽        UP       ▽    
      ▽        ▽        ▽       ⌘TAB      ▽           ▽       ⌃RET     LEFT     DOWN    RIGHT  
 
@@ -241,7 +241,7 @@ _QMK ✓ (`DYrAK` layer 4: ext-num)_
 ```
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        ▽     KP_DIVID KP_MULTI  MINUS      ▽    
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        7        8        9     KP_PLUS     ▽    
-     ▽       sk⇧      sk⌃      sk⌥      sk⌘       ▽           ▽        4        5        6     KP_PLUS     ▽    
+     ▽      skht⇧    skht⌃    skht⌥    skht⌘      ▽           ▽        4        5        6     KP_PLUS     ▽    
      ▽        ▽        ▽        ▽        ▽        ▽       LPAR        RPAR      ▽        1        2        3     KP_ENTER    ▽    
      ▽        ▽        ▽        ▽        ▽           0        0      KP_DOT  KP_ENTER    ▽    
 
@@ -257,7 +257,7 @@ _QMK ✓ (`DYrAK` layer 5: ext-wnav)_
 ```
      ▽        F1       F2       F3       F4       F5       ▽           ▽        F6       F7       F8       F9      F10      F11   
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        ▽        ▽        ▽        ▽       F12   
-    CAPS     sk⇧      sk⌘      sk⌥      sk⌃      ⌃TAB        LEFT     DOWN      UP     RIGHT      ▽        ▽    
+    CAPS    skht⇧    skht⌘    skht⌥    skht⌃     ⌃TAB        LEFT     DOWN      UP     RIGHT      ▽        ▽    
      ▽        ▽        ▽        ▽        ▽      ⌃LEFT     LPAR        RPAR      ▽      PG_DN    PG_UP      ▽        UP       ▽    
      ▽        ▽        ▽       ⌥TAB      ▽           ▽        ⌘X      LEFT     DOWN    RIGHT  
 
@@ -282,7 +282,7 @@ _QMK ✓ (`DYrAK` layer 6: ext-wnum)_
 ```
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        ▽     KP_DIVID KP_MULTI  MINUS      ▽    
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽        7        8        9     KP_PLUS     ▽    
-     ▽       sk⇧      sk⌘      sk⌥      sk⌃       ▽           ▽        4        5        6     KP_PLUS     ▽    
+     ▽      skht⇧    skht⌘    skht⌥    skht⌃      ▽           ▽        4        5        6     KP_PLUS     ▽    
      ▽        ▽        ▽        ▽        ▽        ▽       LPAR        RPAR      ▽        1        2        3     KP_ENTER    ▽    
      ▽        ▽        ▽        ▽        ▽           0        0      KP_DOT  KP_ENTER    ▽    
 
@@ -298,7 +298,7 @@ _QMK ✓ (`DYrAK` layer 7: ext-func)_
 ```
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽        ▽       F10      F11      F12       ▽        ▽    
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽       F12       F7       F8       F9       ▽        ▽    
-     ▽       sk⇧      sk⌃      sk⌥      sk⌘       ▽          F11       F4       F5       F6       ▽        ▽    
+     ▽      skht⇧    skht⌃    skht⌥    skht⌘      ▽          F11       F4       F5       F6       ▽        ▽    
      ▽        ▽        ▽        ▽        ▽        ▽        ▽           ▽       F10       F1       F2       F3       ▽        ▽    
      ▽        ▽        ▽        ▽        ▽           ▽        ▽        ▽        ▽        ▽    
 

--- a/config/slicemk_ergodox.keymap
+++ b/config/slicemk_ergodox.keymap
@@ -246,6 +246,14 @@
       bindings = <&kp>, <&key_repeat>;
 	    display-name = "Mod-Tap-Repeat";
 	  };
+    skht: sticky_key_hold_tap {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      flavor = "tap-preferred";
+      tapping-term-ms = <TAP_TERM_MS>;
+      bindings = <&kp>, <&sk>;
+      display-name = "Sticky-Key-Hold-Tap";
+    };
     leader: leader {
       compatible = "zmk,behavior-leader-key";
       #binding-cells = <0>;
@@ -573,7 +581,7 @@
   &trans     &trans     &trans     &trans     &trans     &trans     &kp LG(GRAVE)    &trans     &trans     &trans     &trans     &trans     &trans     &kp F12
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ CMD+`    │      │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ F12      │
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &caps_word &sk LSHFT  &sk LCTRL  &sk LALT   &sk LGUI   &kp LC(TAB)                             &kp LEFT   &kp DOWN   &kp UP     &kp RIGHT  &trans     &trans
+  &caps_word &skht LSHFT LSHFT  &skht LCTRL LCTRL  &skht LALT LALT   &skht LGUI LGUI   &kp LC(TAB)                             &kp LEFT   &kp DOWN   &kp UP     &kp RIGHT  &trans     &trans
 //│ CAPS WRD │ SHIFT    │ CTRL     │ ALT      │ GUI      │ CTL+TAB  │          │      │          │ ←        │ ↓        │ ↑        │ →        │ TRANS    │ TRANS    │
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans     &kp LG(LEFT) &kp LPAR        &kp RPAR     &trans     &kp PG_DN  &kp PG_UP  &trans     &kp UP     &trans
@@ -605,7 +613,7 @@
   &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &trans     &kp N7     &kp N8     &kp N9     &kp KP_PLUS &trans
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │      │ TRANS    │ TRANS    │ 7        │ 8        │ 9        │ KP +     │ TRANS    │ 
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &trans     &sk LSHFT  &sk LCTRL  &sk LALT   &sk LGUI   &trans                                  &trans     &kp N4     &kp N5     &kp N6     &kp KP_PLUS &trans
+  &trans     &skht LSHFT LSHFT  &skht LCTRL LCTRL  &skht LALT LALT   &skht LGUI LGUI   &trans                                  &trans     &kp N4     &kp N5     &kp N6     &kp KP_PLUS &trans
 //│ TRANS    │ SHIFT    │ CTRL     │ ALT      │ GUI      │ TRANS    │          │      │          │ TRANS    │ 4        │ 5        │ 6        │ KP +     │ TRANS    │ 
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans     &trans     &kp LPAR          &kp RPAR   &trans     &kp N1     &kp N2     &kp N3     &kp KP_ENTER &trans
@@ -637,7 +645,7 @@
   &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &trans     &trans     &trans     &trans     &trans     &kp F12
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │      │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ F12      │
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &caps_word &sk LSHFT  &sk LGUI   &sk LALT   &sk LCTRL  &kp LC(TAB)                             &kp LEFT   &kp DOWN   &kp UP     &kp RIGHT  &trans     &trans
+  &caps_word &skht LSHFT LSHFT  &skht LGUI LGUI   &skht LALT LALT   &skht LCTRL LCTRL  &kp LC(TAB)                             &kp LEFT   &kp DOWN   &kp UP     &kp RIGHT  &trans     &trans
 //│ CAPS WRD │ SHIFT    │ WIN      │ ALT      │ CTRL     │ CTL+TAB  │          │      │          │ ←        │ ↓        │ ↑        │ →        │ TRANS    │ TRANS    │
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans     &kp LC(LEFT) &kp LPAR        &kp RPAR     &trans     &kp PG_DN  &kp PG_UP  &trans     &kp UP     &trans
@@ -669,7 +677,7 @@
   &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &trans     &kp N7     &kp N8     &kp N9     &kp KP_PLUS &trans
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │      │ TRANS    │ TRANS    │ 7        │ 8        │ 9        │ KP +     │ TRANS    │ 
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &trans     &sk LSHFT  &sk LGUI   &sk LALT   &sk LCTRL  &trans                                  &trans     &kp N4     &kp N5     &kp N6     &kp KP_PLUS &trans
+  &trans     &skht LSHFT LSHFT  &skht LGUI LGUI   &skht LALT LALT   &skht LCTRL LCTRL  &trans                                  &trans     &kp N4     &kp N5     &kp N6     &kp KP_PLUS &trans
 //│ TRANS    │ SHIFT    │ WIN      │ ALT      │ CTRL     │ TRANS    │          │      │          │ TRANS    │ 4        │ 5        │ 6        │ KP +     │ TRANS    │ 
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans     &trans     &kp LPAR          &kp RPAR   &trans     &kp N1     &kp N2     &kp N3     &kp KP_ENTER &trans
@@ -701,7 +709,7 @@
   &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &kp F12    &kp F7     &kp F8     &kp F9     &trans     &trans
 //│ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │ TRANS    │      │ TRANS    │ F12      │ F7       │ F8       │ F9       │ TRANS    │ TRANS
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
-  &trans     &sk LSHFT  &sk LCTRL  &sk LALT   &sk LGUI   &trans                                  &kp F11    &kp F4     &kp F5     &kp F6     &trans     &trans
+  &trans     &skht LSHFT LSHFT  &skht LCTRL LCTRL  &skht LALT LALT   &skht LGUI LGUI   &trans                                  &kp F11    &kp F4     &kp F5     &kp F6     &trans     &trans
 //│ TRANS    │ SHIFT    │ CTRL     │ ALT      │ GUI      │ TRANS    │          │      │          │ F11      │ F4       │ F5       │ F6       │ TRANS    │ TRANS
 //├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤      ├──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
   &trans     &trans     &trans     &trans     &trans     &trans     &trans            &trans     &kp F10    &kp F1     &kp F2     &kp F3     &trans     &trans

--- a/config/slicemk_ergodox.keymap
+++ b/config/slicemk_ergodox.keymap
@@ -51,6 +51,11 @@
     flavor = "tap-preferred";
 };
 
+&sk {
+    release-after-ms = <3000>;
+    lazy;
+};
+
 / {
     combos {
         compatible = "zmk,combos";

--- a/tools/keymap/layers.py
+++ b/tools/keymap/layers.py
@@ -89,6 +89,9 @@ def display(token: str) -> str:
     m = re.fullmatch(r"&sk (\w+)", t)
     if m:
         return "sk" + (_MOD_SYM.get(m.group(1)) or ":" + m.group(1).lower())
+    m = re.fullmatch(r"&skht (\w+) (\w+)", t)   # tap param is second
+    if m:
+        return "skht" + (_MOD_SYM.get(m.group(2)) or ":" + m.group(2).lower())
     m = re.fullmatch(r"&t?lt (L_[A-Z0-9_]+) (\w+)", t)
     if m:
         return f"→{m.group(1).replace('L_EXT_', '').replace('L_', '').lower()}/{_atom_label(m.group(2))}"

--- a/tools/keymap/translate.py
+++ b/tools/keymap/translate.py
@@ -162,6 +162,9 @@ def canon_zmk(token: str) -> tuple[str, bool]:
     m = re.fullmatch(r"&sk (\w+)", token)
     if m:
         return f"OSM({_ZMK_MOD.get(m.group(1), m.group(1))})", True
+    m = re.fullmatch(r"&skht (\w+) (\w+)", token)   # hold=&kp, tap=&sk; canonical is the tap (OSM)
+    if m:
+        return f"OSM({_ZMK_MOD.get(m.group(2), m.group(2))})", True
     m = re.fullmatch(r"&t?mt (\w+) (\w+)", token)   # &mt / &tmt with simple mod
     if m and m.group(1) in _ZMK_MOD:
         return f"MT({_ZMK_MOD[m.group(1)]},{_atom_zmk(m.group(2))})", True


### PR DESCRIPTION
## Summary

- Overrides `&sk` behavior in `config/slicemk_ergodox.keymap`
- `release-after-ms = <3000>` — 3× the default 1000ms timeout
- `lazy` — defers modifier registration until combined with next keypress, matching QMK `OSM` default behavior

`quick-release` was considered and explicitly not added — it controls when the mod is *released*, not when it *arrives*, and doesn't match QMK parity.

## Test plan

- [ ] Run `build-zmk-layout` Action to verify clean ZMK build
- [ ] Flash to home keyboard and verify sticky mods feel right at 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BDfbqx2VyWZYpfUaKLQL8