### PR TITLE
Add prev/next desktop shortcuts to base-mac right thumb

### DIFF
--- a/DYrAK/keymap.c
+++ b/DYrAK/keymap.c
@@ -29,8 +29,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TRANSPARENT, KC_Z,           KC_X,           KC_C,           KC_V,           KC_B,           KC_LBRC,                                        KC_RBRC,        KC_N,           KC_M,           KC_COMMA,       KC_DOT,         KC_SLASH,       KC_TRANSPARENT,
     LGUI(LCTL(KC_SPACE)),KC_TRANSPARENT, KC_TRANSPARENT, CMD_TAB,   KC_LEFT_SHIFT,                                                                                                 KC_RIGHT_SHIFT, QK_REPEAT_KEY, KC_TRANSPARENT, KC_TRANSPARENT, KC_TRANSPARENT,
                                                                                                     QK_LEAD,          DUAL_FUNC_0,    TO(9),          QK_REPEAT_KEY,
-                                                                                                                    KC_AUDIO_VOL_UP,LAYER_ID,
-                                                                                    LT(3, KC_BSPC), KC_LEFT_GUI,    KC_AUDIO_VOL_DOWN,KC_TRANSPARENT, MT(MOD_RGUI, KC_ENTER),LT(4, KC_SPACE)
+                                                                                                                    KC_AUDIO_VOL_UP,LCTL(KC_LEFT),
+                                                                                    LT(3, KC_BSPC), KC_LEFT_GUI,    KC_AUDIO_VOL_DOWN,LCTL(KC_RIGHT), MT(MOD_RGUI, KC_ENTER),LT(4, KC_SPACE)
   ),
   [1] = LAYOUT_ergodox_pretty( // base-win
     KC_ESCAPE,      KC_1,           KC_2,           KC_3,           KC_4,           KC_5,           KC_TRANSPARENT,                                 KC_TRANSPARENT, KC_6,           KC_7,           KC_8,           KC_9,           KC_0,           KC_MINUS,

--- a/LAYERS.md
+++ b/LAYERS.md
@@ -38,13 +38,12 @@ _QMK ✓ (`DYrAK` layer 0: base-mac)_
   ⌃⌘SPACE     ·        ·      cmdtab     ⇧           ⇧       RPT       ·        ·        ·    
 
   thumbs   L:   LEAD     ⌃⌘Q/⏯    |  →nav/BSP     ⌘        vol+    |    vol-  
-           R: TO:layer    RPT     |     ·       ⌘/RET    →num/SPA  |     ·    
+           R: TO:layer    RPT     |   ⌃LEFT     ⌘/RET    →num/SPA  |   ⌃RIGHT 
 ```
 
-**QMK differs here (2):**
+**QMK differs here (1):**
 
 - pos 29: QMK `KC_F24` vs ZMK `&none`
-- pos 70: QMK `LAYER_ID` vs ZMK `&none`
 
 ### 1. base-fortnite
 

--- a/config/slicemk_ergodox.keymap
+++ b/config/slicemk_ergodox.keymap
@@ -368,11 +368,11 @@
                                               &leader        &mt LC(LG(Q)) C_PP       &to L_LAYERS &key_repeat
 //                                            │ TOG NAV      │ LOCK/PP         │      │ TO LYR     │ REPEAT       │
 //                        ╭───────────────────├──────────────┼─────────────────┤      ├────────────┼──────────────┤──────────────────╮
-                          &tlt L_EXT_NAV BSPC &kp LCMD       &kp C_VOL_UP             &none        &tmt RCMD RET &tlt L_EXT_NUM SPACE
-//                        │ LT SC/BSPC        │ CMD          │ VOL+            │      │ NONE       │ CMD/RET      │ L: NUM/SPC       │
+                          &tlt L_EXT_NAV BSPC &kp LCMD       &kp C_VOL_UP             &kp LC(LEFT)  &tmt RCMD RET &tlt L_EXT_NUM SPACE
+//                        │ LT SC/BSPC        │ CMD          │ VOL+            │      │ PREV DSK   │ CMD/RET      │ L: NUM/SPC       │
 //                        ╰───────────────────┴──────────────┼─────────────────┤      ├────────────┼──────────────┴──────────────────╯
-                                                             &kp C_VOL_DN             &none
-//                                                           │ VOL-            │      │ NONE       │
+                                                             &kp C_VOL_DN             &kp LC(RIGHT)
+//                                                           │ VOL-            │      │ NEXT DSK   │
 //                                                           ╰─────────────────╯      ╰────────────╯
 			>;
 		};


### PR DESCRIPTION
## Summary

- Positions 72 and 76 on the right thumb cluster were dead keys on base-mac; assign them to macOS Mission Control desktop switching
- pos 72 (upper-inner 1u key) → Ctrl+Left (prev desktop) — matches the leftward slant of that key in the thumb cluster
- pos 76 (lower 1u key, below 72) → Ctrl+Right (next desktop)
- QMK uses `LCTL()` long form (not `C()` shorthand) so the parity translator correctly recognizes the match with ZMK's `LC()`

## Test plan

- [ ] Run `build-zmk-layout` Action (ZMK `config/` changed)
- [ ] Run `fetch-and-build-layout` Action (QMK `DYrAK/` changed)
- [ ] Flash ZMK and verify Ctrl+Left / Ctrl+Right switch desktops on macOS
- [ ] Confirm parity tool reports no new drift: `python3 tools/keymap/parity.py --layer mac`
- [ ] Run `/updating-kle` — pos 72 and 76 changed from dead to active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFnPh4gb98rdHVmwpFADMh