### PR TITLE
Inline ZMK workflow; bump actions to clear Node.js 20 warnings

### DIFF
--- a/.github/workflows/build-zmk-layout.yml
+++ b/.github/workflows/build-zmk-layout.yml
@@ -2,13 +2,174 @@ name: Build ZMK Layout
 
 on: [workflow_dispatch]
 
+# Inlined from slicemk/zmk/.github/workflows/build-user-config.yml@main
+# with action versions bumped from v4 to current (checkout@v7, cache@v6,
+# upload-artifact@v7) to silence Node.js 20 deprecation warnings.
+#
+# We do NOT use the upstream zmkfirmware reusable workflow because upstream@main
+# added a board-compat step (west boards / CONFIG_ZMK_BOARD_COMPAT) that the
+# slicemk fork doesn't implement, which breaks the build. Inlining lets us
+# stay on the slicemk build logic while controlling our own action versions.
+
+env:
+  BUILD_MATRIX_PATH: build.yaml
+  CONFIG_PATH: config
+  ARCHIVE_NAME: zmk_firmware_${{ github.run_id }}
+  FALLBACK_BINARY: bin
+
 jobs:
+  matrix:
+    runs-on: ubuntu-22.04
+    name: Fetch Build Keyboards
+    outputs:
+      build_matrix: ${{ env.build_matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install yaml2json
+        run: python3 -m pip install remarshal
+
+      - name: Fetch Build Matrix
+        run: |
+          echo "build_matrix=$(yaml2json '${{ env.BUILD_MATRIX_PATH }}' | jq -c .)" >> $GITHUB_ENV
+          yaml2json "${{ env.BUILD_MATRIX_PATH }}" | jq
+
   build:
-    # slicemk/zmk's reusable workflow, NOT zmkfirmware upstream: upstream@main added a
-    # board-compat (`west boards` / CONFIG_ZMK_BOARD_COMPAT) step that the slicemk fork
-    # doesn't implement, which breaks the build. Matches xudongzheng's working underglow config.
-    uses: slicemk/zmk/.github/workflows/build-user-config.yml@main
-    with:
-      build_matrix_path: build.yaml
-      config_path: config
-      archive_name: zmk_firmware_${{ github.run_id }}
+    runs-on: ubuntu-latest
+    container:
+      image: zmkfirmware/zmk-build-arm:stable
+    needs: matrix
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.build_matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Create build directory
+        run: |
+          echo "build_dir=$(mktemp -d)" >> $GITHUB_ENV
+
+      - name: Prepare variables
+        shell: sh -x {0}
+        env:
+          board: ${{ matrix.board }}
+          shield: ${{ matrix.shield }}
+          artifact_name: ${{ matrix.artifact-name }}
+          snippet: ${{ matrix.snippet }}
+        run: |
+          if [ -e zephyr/module.yml ]; then
+            export zmk_load_arg=" -DZMK_EXTRA_MODULES='${GITHUB_WORKSPACE}'"
+            new_tmp_dir="${TMPDIR:-/tmp}/zmk-config"
+            mkdir -p "${new_tmp_dir}"
+            echo "base_dir=${new_tmp_dir}" >> $GITHUB_ENV
+          else
+            echo "base_dir=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+          fi
+
+          if [ -n "${snippet}" ]; then
+            extra_west_args="-S \"${snippet}\""
+          fi
+
+          echo "zephyr_version=${ZEPHYR_VERSION}" >> $GITHUB_ENV
+          echo "extra_west_args=${extra_west_args}" >> $GITHUB_ENV
+          echo "extra_cmake_args=${shield:+-DSHIELD=\"$shield\"}${zmk_load_arg}" >> $GITHUB_ENV
+          echo "display_name=${shield:+$shield - }${board}" >> $GITHUB_ENV
+          echo "artifact_name=${artifact_name:-${shield:+$shield-}${board}-zmk}" >> $GITHUB_ENV
+
+      - name: Copy config files to isolated temporary directory
+        run: |
+          if [ "${{ env.base_dir }}" != "${GITHUB_WORKSPACE}" ]; then
+            mkdir "${{ env.base_dir }}/${{ env.CONFIG_PATH }}"
+            cp -R ${{ env.CONFIG_PATH }}/* "${{ env.base_dir }}/${{ env.CONFIG_PATH }}/"
+          fi
+
+      - name: Cache west modules
+        uses: actions/cache@v6
+        continue-on-error: true
+        env:
+          cache_name: cache-zephyr-${{ env.zephyr_version }}-modules
+        with:
+          path: |
+            ${{ env.base_dir }}/modules/
+            ${{ env.base_dir }}/tools/
+            ${{ env.base_dir }}/zephyr/
+            ${{ env.base_dir }}/bootloader/
+            ${{ env.base_dir }}/zmk/
+          key: ${{ runner.os }}-build-${{ env.cache_name }}-${{ hashFiles('**/west.yml', '**/build.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache_name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: West Init
+        working-directory: ${{ env.base_dir }}
+        run: west init -l "${{ env.base_dir }}/${{ env.CONFIG_PATH }}"
+
+      - name: West Update
+        working-directory: ${{ env.base_dir }}
+        run: west update
+
+      - name: West Zephyr export
+        working-directory: ${{ env.base_dir }}
+        run: west zephyr-export
+
+      - name: West Build (${{ env.display_name }})
+        working-directory: ${{ env.base_dir }}
+        shell: sh -x {0}
+        run: west build -s zmk/app -d "${{ env.build_dir }}" -b "${{ matrix.board }}" ${{ env.extra_west_args }} -- -DZMK_CONFIG=${{ env.base_dir }}/${{ env.CONFIG_PATH }} ${{ env.extra_cmake_args }} ${{ matrix.cmake-args }}
+
+      - name: ${{ env.display_name }} Kconfig file
+        run: |
+          if [ -f "${{ env.build_dir }}/zephyr/.config" ]
+          then
+            grep -v -e "^#" -e "^$" "${{ env.build_dir }}/zephyr/.config" | sort
+          else
+            echo "No Kconfig output"
+          fi
+        if: ${{ !cancelled() }}
+
+      - name: ${{ env.display_name }} Devicetree file
+        run: |
+          if [ -f "${{ env.build_dir }}/zephyr/zephyr.dts" ]
+          then
+            cat "${{ env.build_dir }}/zephyr/zephyr.dts"
+          elif [ -f "${{ env.build_dir }}/zephyr/zephyr.dts.pre" ]
+          then
+            cat -s "${{ env.build_dir }}/zephyr/zephyr.dts.pre"
+          else
+            echo "No Devicetree output"
+          fi
+        if: ${{ !cancelled() }}
+
+      - name: Rename artifacts
+        shell: sh -x {0}
+        run: |
+          mkdir "${{ env.build_dir }}/artifacts"
+          if [ -f "${{ env.build_dir }}/zephyr/zmk.uf2" ]
+          then
+            cp "${{ env.build_dir }}/zephyr/zmk.uf2" "${{ env.build_dir }}/artifacts/${{ env.artifact_name }}.uf2"
+          elif [ -f "${{ env.build_dir }}/zephyr/zmk.${{ env.FALLBACK_BINARY }}" ]
+          then
+            cp "${{ env.build_dir }}/zephyr/zmk.${{ env.FALLBACK_BINARY }}" "${{ env.build_dir }}/artifacts/${{ env.artifact_name }}.${{ env.FALLBACK_BINARY }}"
+          fi
+
+      - name: Archive (${{ env.display_name }})
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-${{ env.artifact_name }}
+          path: ${{ env.build_dir }}/artifacts
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    name: Merge Output Artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: ${{ env.ARCHIVE_NAME }}
+          pattern: artifact-*
+          delete-merged: true

--- a/.github/workflows/build-zmk-layout.yml
+++ b/.github/workflows/build-zmk-layout.yml
@@ -3,8 +3,10 @@ name: Build ZMK Layout
 on: [workflow_dispatch]
 
 # Inlined from slicemk/zmk/.github/workflows/build-user-config.yml@main
-# with action versions bumped from v4 to current (checkout@v7, cache@v6,
+# Source commit: a17266847dcd5e3e202ed7eb559665f22a10b86e (2024-09-26)
+# Action versions bumped from v4 to current (checkout@v7, cache@v6,
 # upload-artifact@v7) to silence Node.js 20 deprecation warnings.
+# To check for upstream changes: diff this file against slicemk/zmk at HEAD.
 #
 # We do NOT use the upstream zmkfirmware reusable workflow because upstream@main
 # added a board-compat step (west boards / CONFIG_ZMK_BOARD_COMPAT) that the
@@ -16,7 +18,6 @@ env:
   CONFIG_PATH: config
   ARCHIVE_NAME: zmk_firmware_${{ github.run_id }}
   FALLBACK_BINARY: bin
-
 jobs:
   matrix:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

- GitHub deprecated Node.js 20 as an Actions runtime; `slicemk/zmk`'s reusable workflow still targets it via `checkout@v4`, `cache@v4`, and `upload-artifact@v4`, generating warnings on every ZMK build run.
- Inlined `slicemk/zmk/.github/workflows/build-user-config.yml` directly into `build-zmk-layout.yml`, replacing the `uses:` delegation so we control action versions independently of upstream.
- Bumped all three to current: `checkout@v7`, `cache@v6`, `upload-artifact@v7` (including the merge variant).
- Preserved the slicemk-vs-upstream distinction: the slicemk build logic (not `zmkfirmware/zmk` upstream) is kept, because upstream added a `board-compat` step the slicemk fork doesn't implement.

## Test plan

- [ ] Trigger the `Build ZMK Layout` workflow manually via workflow_dispatch and verify it completes without the Node.js 20 deprecation warnings
- [ ] Confirm the artifact is produced with the expected name (`zmk_firmware_<run_id>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFnPh4gb98rdHVmwpFADMh